### PR TITLE
Update index.php

### DIFF
--- a/public/includes/lib/drag-drop-featured-image/index.php
+++ b/public/includes/lib/drag-drop-featured-image/index.php
@@ -550,7 +550,7 @@
 		 * @return string
 		 */
 		public function modify_admin_body_class($classes){
-			if ($this->wordpress_version >= 38){ $classes .= 'wp38'; }
+			if ($this->wordpress_version >= 38){ $classes .= ' wp38'; }
 			return $classes;
 		}
 


### PR DESCRIPTION
Adds a space to the "wp38" class name.  Currently this is appended to existing admin body classes instead of being added to the classes.  This change adds the class instead of modifying existing classes and fixes conflicts with plugins such as Ninja Forms.