### PR TITLE
Corrects GitHub URL

### DIFF
--- a/draw-attention.php
+++ b/draw-attention.php
@@ -16,7 +16,7 @@ Text Domain:       draw-attention
 License:           GPL-2.0+
 License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
 Domain Path:       /languages
-GitHub Plugin URI: https://github.com/tylerdigital/drawattention/
+GitHub Plugin URI: https://github.com/tylerdigital/draw-attention
 */
 
 // If this file is called directly, abort.


### PR DESCRIPTION
Adds a missing dash to the GitHub URL referenced in the plugin's header, which currently is a 404.