### PR TITLE
Silence WP 6.9.1 cmb2-scripts dep notice; scope newsletter assets

### DIFF
--- a/admin/class-drawattention-admin.php
+++ b/admin/class-drawattention-admin.php
@@ -187,8 +187,24 @@ if ( !class_exists( 'DrawAttention_Admin' ) ) {
 					'ajaxURL' => admin_url( 'admin-ajax.php' ),
 				) );
 				wp_enqueue_script( $this->plugin_slug . '-admin-script', array(),  DrawAttention::VERSION );
+
+				// Silence WP 6.9.1's missing-dep notice for our cmb2-scripts dep — CMB2 doesn't always
+				// register that handle by print time. The filter self-removes after firing.
+				add_filter( 'doing_it_wrong_trigger_error', array( $this, 'suppress_cmb2_dep_notice' ), 10, 3 );
 			}
 
+		}
+
+		public function suppress_cmb2_dep_notice( $trigger, $function_name, $message ) {
+			if ( 'WP_Scripts::add' !== $function_name ) {
+				return $trigger;
+			}
+			$pattern = '/\b' . preg_quote( $this->plugin_slug . '-admin-script', '/' ) . '\b.*\bcmb2-scripts\b/s';
+			if ( preg_match( $pattern, (string) $message ) ) {
+				remove_filter( 'doing_it_wrong_trigger_error', array( $this, 'suppress_cmb2_dep_notice' ), 10 );
+				return false;
+			}
+			return $trigger;
 		}
 
 		public function fix_mainwp_conflict()

--- a/admin/class-drawattention-admin.php
+++ b/admin/class-drawattention-admin.php
@@ -188,7 +188,7 @@ if ( !class_exists( 'DrawAttention_Admin' ) ) {
 				) );
 				wp_enqueue_script( $this->plugin_slug . '-admin-script', array(),  DrawAttention::VERSION );
 
-				// Silence WP 6.9.1's missing-dep notice for our cmb2-scripts dep — CMB2 doesn't always
+				// Silence WP 6.9.1's missing dep notice for our cmb2-scripts dep — CMB2 doesn't always
 				// register that handle by print time. The filter self-removes after firing.
 				add_filter( 'doing_it_wrong_trigger_error', array( $this, 'suppress_cmb2_dep_notice' ), 10, 3 );
 			}

--- a/public/includes/da-newsletter.php
+++ b/public/includes/da-newsletter.php
@@ -49,11 +49,11 @@ class DrawAttention_Newsletter {
                         <button id='openModalButton'> <span>" . __( 'SUBSCRIBE', 'draw-attention' ) . "</span> </button>
                     </div>
                     <div class='content-notice'>
-                        <span>" . __( "We'll only send you awesome content. Never spam.", 'draw-attention' ) . "</span>
+                        <span>" . __( "We'll only send you awesome content. Never spam.", 'draw-attention' ) . '</span>
                     </div>
                 </div>
             </div>
-        ";
+        ';
 	}
 
 	public function newsletter_modal_dialog() {
@@ -105,13 +105,13 @@ class DrawAttention_Newsletter {
                             </div>
                             
                             <div data-showonreset data-hideonsuccess class='content-notice md-content-notice'>
-                                <span>" . __( 'We keep your email safe and private, without drawing attention.', 'draw-attention' ) . "</span>
+                                <span>" . __( 'We keep your email safe and private, without drawing attention.', 'draw-attention' ) . '</span>
                             </div>
                         </div>
                     </form>
                 </div>
             </div>
-        ";
+        ';
 	}
 
 	public function add_newsletter_widget() {

--- a/public/includes/da-newsletter.php
+++ b/public/includes/da-newsletter.php
@@ -20,8 +20,17 @@ class DrawAttention_Newsletter {
 	}
 
 	public function enqueue_meta_box_assets() {
-		wp_enqueue_style( 'da-custom-meta-box-styles', $this->plugin_directory . '/assets/css/custom-meta-box-styles.css', array(), DrawAttention::VERSION );
+		if ( ! $this->is_da_image_edit_screen() ) {
+			return;
+		}
+
+		wp_enqueue_style( 'da-custom-meta-box-styles', $this->plugin_directory . 'assets/css/custom-meta-box-styles.css', array(), DrawAttention::VERSION );
 		wp_enqueue_script( 'da-news-letter-js', $this->plugin_directory . 'assets/js/news-letter.js', array(), DrawAttention::VERSION );
+	}
+
+	private function is_da_image_edit_screen() {
+		$current_screen = get_current_screen();
+		return $current_screen && 'post' === $current_screen->base && 'da_image' === $current_screen->post_type;
 	}
 
 	public function metabox_newsletter_component() {
@@ -30,30 +39,25 @@ class DrawAttention_Newsletter {
 
                 <div class='content-container'>
                     <div>
-                        <img src='" . $this->plugin_directory . "/assets/images/news-letter.svg' alt='Newsletter Image'>
+                        <img src='" . $this->plugin_directory . "assets/images/news-letter.svg' alt='Newsletter Image'>
                     </div>
                     <div>
                         <p> " . __( 'Stay up to date with the latest from Draw Attention', 'draw-attention' ) . "</p>
                     </div>
                     <div class='outer-content'>
-                        <p>Subscribe now! Get 20% Coupon</p>
+                        <p>" . __( 'Subscribe now! Get 20% Coupon', 'draw-attention' ) . "</p>
                         <button id='openModalButton'> <span>" . __( 'SUBSCRIBE', 'draw-attention' ) . "</span> </button>
                     </div>
                     <div class='content-notice'>
-                        <span>" . __( "We'll only send you awesome content. Never spam.", 'draw-attention' ) . '</span>
+                        <span>" . __( "We'll only send you awesome content. Never spam.", 'draw-attention' ) . "</span>
                     </div>
                 </div>
             </div>
-        ';
+        ";
 	}
 
 	public function newsletter_modal_dialog() {
-		if ( ! is_admin() ) {
-			return;
-		}
-
-		$current_screen = get_current_screen();
-		if ( ! $current_screen || 'post' !== $current_screen->base || 'da_image' !== $current_screen->post_type ) {
+		if ( ! $this->is_da_image_edit_screen() ) {
 			return;
 		}
 
@@ -64,19 +68,19 @@ class DrawAttention_Newsletter {
                 <div class='modal-content modal-content-container'>
                     <div class='close-button-container'>
                         <button id='closeModalButton' class='dismiss-banner' aria-label='Dismiss Notice'>
-                            <img src='" . $this->plugin_directory . "/assets/images/close-icon.svg' alt='Dismiss Notice Icon'>
+                            <img src='" . $this->plugin_directory . "assets/images/close-icon.svg' alt='Dismiss Notice Icon'>
                         </button>
                     </div>
-                    <form  method='POST' class='news-letter-container news-letter-form-container' id='da-newsletter-form' class='_form _form_1 _inline-form  _dark' novalidate='' data-styles-version='5'>
+                    <form method='POST' class='news-letter-container news-letter-form-container _form _form_1 _inline-form _dark' id='da-newsletter-form' novalidate='' data-styles-version='5'>
                         <div class='content-container modal-container'>
                             <div class='modal-content'>
                                 <div class='modal-info'>
-                                    <h2 id='weeklyNewsLetterHeader'> " . __( 'Get our weekly', 'draw-attention' ) . "</span></h2>
+                                    <h2 id='weeklyNewsLetterHeader'> " . __( 'Get our weekly', 'draw-attention' ) . "</h2>
                                     <p class='headline'> " . __( 'newsletter', 'draw-attention' ) . "</p>
                                     <p class='modal-statement'> " . __( 'Get weekly updates on the newest Draw Attention updates, case studies and tips right in your mailbox.', 'draw-attention' ) . "</p>
                                     <label data-hideonsuccess for='da-newsletter-email' class='cta'> " . __( 'Enter your email to get a 20% Coupon', 'draw-attention' ) . "</label>
                                 </div>
-                                <img class='inner-modal-image' src='" . $this->plugin_directory . "/assets/images/letter.svg' alt='Newsletter Image'>
+                                <img class='inner-modal-image' src='" . $this->plugin_directory . "assets/images/letter.svg' alt='Newsletter Image'>
                             </div>
 
                             <div data-showonreset data-hideonsuccess class='_form_element _x45964534 _full_width input-field'>
@@ -101,13 +105,13 @@ class DrawAttention_Newsletter {
                             </div>
                             
                             <div data-showonreset data-hideonsuccess class='content-notice md-content-notice'>
-                                <span>" . __( 'We keep your email safe and private, without drawing attention.', 'draw-attention' ) . '</span>
+                                <span>" . __( 'We keep your email safe and private, without drawing attention.', 'draw-attention' ) . "</span>
                             </div>
                         </div>
                     </form>
                 </div>
             </div>
-        ';
+        ";
 	}
 
 	public function add_newsletter_widget() {


### PR DESCRIPTION
## Asana:
Javascript error in news-letter.js
https://app.asana.com/1/1992899177764/project/1202852195727079/task/1214864639306804?focus=true

## Summary

- Suppress WP 6.9.1's "missing dependency" `doing_it_wrong` notice for the `cmb2-scripts` dep on our admin script — CMB2 doesn't always register the handle by print time. Filter is scoped (handle + dep, word-boundary regex) and self-removes after firing.
- Scope newsletter CSS/JS enqueue to the `da_image` edit screen instead of every admin page; extract the screen check into a shared helper.
- Fix double-slash asset URLs `(/public//assets/...)`, malformed closing tags in the modal HTML, a duplicate `class=` attribute on the form, and a missed translatable string.